### PR TITLE
fix(urlAdapter): keep URL hash if provided

### DIFF
--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -20,17 +20,14 @@ describe('URL', () => {
         urlAdapter.set('bar', 'baz')
         expect(getParams().get('bar')).toBe('baz')
       })
-
-      test('keeps the url hash when setting data', () => {
+      test('keeps the URL hash when setting data', () => {
         window.history.pushState({}, '', '/url/#hash')
         urlAdapter.set('foo', 'bar')
-
         expect(window.location.href).toEqual('http://localhost/url/#hash?foo=bar')
 
         // We have to reset the window location to prevent other tests from having the /url/#hash as active location
         window.history.pushState({}, '', '/')
       })
-
       test('does not add the hash when setting data if no hash is present', () => {
         urlAdapter.set('foo', 'bar')
         expect(window.location.href).toEqual('http://localhost/?foo=bar')

--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -20,6 +20,21 @@ describe('URL', () => {
         urlAdapter.set('bar', 'baz')
         expect(getParams().get('bar')).toBe('baz')
       })
+
+      test('keeps the url hash when setting data', () => {
+        window.history.pushState({}, 'hash_url', '/url/#hash')
+        urlAdapter.set('foo', 'bar')
+
+        expect(window.location.href).toEqual('http://localhost/url/#hash?foo=bar')
+
+        // We have to reset the window location to prevent other tests from having the /url/#hash as active location
+        window.history.pushState({}, 'hash_url', '/')
+      })
+
+      test('does not add the hash when setting data if no hash is present', () => {
+        urlAdapter.set('foo', 'bar')
+        expect(window.location.href).toEqual('http://localhost/?foo=bar')
+      })
     })
     describe('#remove', () => {
       test('removes data by key from storage', () => {

--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -4,15 +4,10 @@ const getParams = () =>
   new URLSearchParams(new URL(window.location.href).search)
 const getHash = () =>
   window.location.hash
-const persist = (params = '') =>
-  setActiveURL(`${window.location.pathname}?${params}`)
-const resetURL = () =>
-  setActiveURL('/')
-const setActiveURL =  (url) =>
-  window.history.pushState({}, '', url)
+const persist = (params = '', hash = '') =>
+  window.history.pushState({}, '', `${window.location.pathname}?${params}${hash}`)
 
 beforeEach(() => persist())
-afterEach(() => resetURL())
 
 describe('URL', () => {
   describe('#get', () => {
@@ -28,7 +23,7 @@ describe('URL', () => {
         expect(getParams().get('bar')).toBe('baz')
       })
       test('keeps the URL hash when setting data', () => {
-        setActiveURL('/url/#hash')
+        persist('', '#hash')
         urlAdapter.set('foo', 'bar')
         expect(getHash()).toEqual('#hash')
       })

--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -5,9 +5,11 @@ const getParams = () =>
 const getHash = () =>
   window.location.hash
 const persist = (params = '') =>
-  window.history.pushState({}, '', `${window.location.pathname}?${params}`)
+  setActiveURL(`${window.location.pathname}?${params}`)
 const resetURL = () =>
-  window.history.pushState({}, '', '/')
+  setActiveURL('/')
+const setActiveURL =  (url) =>
+  window.history.pushState({}, '', url)
 
 beforeEach(() => persist())
 afterEach(() => resetURL())
@@ -26,7 +28,7 @@ describe('URL', () => {
         expect(getParams().get('bar')).toBe('baz')
       })
       test('keeps the URL hash when setting data', () => {
-        window.history.pushState({}, '', '/url/#hash')
+        setActiveURL('/url/#hash')
         urlAdapter.set('foo', 'bar')
         expect(getHash()).toEqual('#hash')
       })

--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -2,10 +2,15 @@ import urlAdapter from '../url'
 
 const getParams = () =>
   new URLSearchParams(new URL(window.location.href).search)
+const getHash = () =>
+  window.location.hash
 const persist = (params = '') =>
   window.history.pushState({}, '', `${window.location.pathname}?${params}`)
+const resetURL = () =>
+  window.history.pushState({}, '', '/')
 
 beforeEach(() => persist())
+afterEach(() => resetURL())
 
 describe('URL', () => {
   describe('#get', () => {
@@ -23,14 +28,11 @@ describe('URL', () => {
       test('keeps the URL hash when setting data', () => {
         window.history.pushState({}, '', '/url/#hash')
         urlAdapter.set('foo', 'bar')
-        expect(window.location.href).toEqual('http://localhost/url/#hash?foo=bar')
-
-        // We have to reset the window location to prevent other tests from having the /url/#hash as active location
-        window.history.pushState({}, '', '/')
+        expect(getHash()).toEqual('#hash')
       })
       test('does not add the hash when setting data if no hash is present', () => {
         urlAdapter.set('foo', 'bar')
-        expect(window.location.href).toEqual('http://localhost/?foo=bar')
+        expect(getHash()).toEqual('')
       })
     })
     describe('#remove', () => {

--- a/src/adapters/__tests__/url.test.js
+++ b/src/adapters/__tests__/url.test.js
@@ -22,13 +22,13 @@ describe('URL', () => {
       })
 
       test('keeps the url hash when setting data', () => {
-        window.history.pushState({}, 'hash_url', '/url/#hash')
+        window.history.pushState({}, '', '/url/#hash')
         urlAdapter.set('foo', 'bar')
 
         expect(window.location.href).toEqual('http://localhost/url/#hash?foo=bar')
 
         // We have to reset the window location to prevent other tests from having the /url/#hash as active location
-        window.history.pushState({}, 'hash_url', '/')
+        window.history.pushState({}, '', '/')
       })
 
       test('does not add the hash when setting data if no hash is present', () => {

--- a/src/adapters/url.js
+++ b/src/adapters/url.js
@@ -6,7 +6,7 @@ const persistPipe = fn =>
   pipe(
     fn,
     (params = '') =>
-      window.history.pushState({}, '', `${window.location.pathname}${window.location.hash}?${params}`)
+      window.history.pushState({}, '', `${window.location.pathname}?${params}${window.location.hash}`)
   )(getParams())
 
 export default {

--- a/src/adapters/url.js
+++ b/src/adapters/url.js
@@ -6,7 +6,7 @@ const persistPipe = fn =>
   pipe(
     fn,
     (params = '') =>
-      window.history.pushState({}, '', `${window.location.pathname}?${params}`)
+      window.history.pushState({}, '', `${window.location.pathname}${window.location.hash}?${params}`)
   )(getParams())
 
 export default {


### PR DESCRIPTION
There was an issue with the previous implementation of the URL adapter for browserstore.js. Any URL hash that was available would be removed as soon as something was persisted through the adapter. This PR changes that behavior to keep the URL hash.