### PR TITLE
feat: add error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,36 @@ const myStorage = {
   remove: key => /* remove data from storage */,
   clear: () => /* clear storage */,
   afterGet: data => /* manipulate data after getting it */,
-  beforeSet: data => /* manipulate data before setting it */
+  beforeSet: data => /* manipulate data before setting it */,
+  onGetError: (err, key) => /* optional. gracefully handle errors occurring when calling `get` */,
+  onSetError: (err, key, data) => /* optional. gracefully handle errors occurring when calling `set` */,
+  onRemoveError: (err, key) => /* optional. gracefully handle errors occurring when calling `remove` */,
+  onClearError: (err, key) => /* optional. gracefully handle errors occurring when calling `clear` */,
 }
 
 const myStore = createStore(myStorage)
+```
+
+## Handling errors
+### Errors in stores
+BrowserStore comes with error handling built-in. 
+You can catch every error thrown by one of the [public methods](#api) by defining `onMethodNameError` methods on your adapter.  
+For example, if the `get` method of an adapter throws an error, the `onGetError` method is called. 
+You can [create custom adapter](#building-your-own-adapter) to gracefully handle these errors.
+
+For example, let's say you try to set a value into the store created from the `localStorageAdapter`, but the `localStorage` is full.
+`localStorage` throws a `QuotaExceededError` when it's full, and you try to write data to it. When this happens, you might want to clear the `localStorage` to be able to save values to it again.
+You can do this by defining the `onSetError` method in your custom adapter, like this:
+```js
+import localStorageAdapter from 'browserstore.js/es/adapters/localStorage'
+
+
+const myLocalStorageAdapter = {...localStorageAdapter, ...{
+  onSetError(err, key, data) {
+    this.clear()
+    localStorage.set(key, data)
+  }
+}}
 ```
 
 ## Using BrowserStore in different environments

--- a/README.md
+++ b/README.md
@@ -276,36 +276,39 @@ const myStorage = {
   clear: () => /* clear storage */,
   afterGet: data => /* manipulate data after getting it */,
   beforeSet: data => /* manipulate data before setting it */,
-  onGetError: (err, key) => /* optional. gracefully handle errors occurring when calling `get` */,
-  onSetError: (err, key, data) => /* optional. gracefully handle errors occurring when calling `set` */,
-  onRemoveError: (err, key) => /* optional. gracefully handle errors occurring when calling `remove` */,
-  onClearError: (err, key) => /* optional. gracefully handle errors occurring when calling `clear` */,
+  onGetError: (err, key) => /* handle errors occurring when calling `get` */,
+  onSetError: (err, key, value) => /* handle errors occurring when calling `set` */,
+  onRemoveError: (err, key) => /* handle errors occurring when calling `remove` */,
+  onClearError: (err, key) => /* handle errors occurring when calling `clear` */,
 }
 
 const myStore = createStore(myStorage)
 ```
 
 ## Handling errors
-### Errors in stores
-BrowserStore comes with error handling built-in. 
-You can catch every error thrown by one of the [public methods](#api) by defining `onMethodNameError` methods on your adapter.  
-For example, if the `get` method of an adapter throws an error, the `onGetError` method is called. 
-You can [create custom adapter](#building-your-own-adapter) to gracefully handle these errors.
 
-For example, let's say you try to set a value into the store created from the `localStorageAdapter`, but the `localStorage` is full.
-`localStorage` throws a `QuotaExceededError` when it's full, and you try to write data to it. When this happens, you might want to clear the `localStorage` to be able to save values to it again.
-You can do this by defining the `onSetError` method in your custom adapter, like this:
+### Errors in stores
+
+BrowserStore comes with built-in error handling.
+You can catch errors thrown by any of the [public methods](#api) by defining callbacks methods on your adapter (with the `onMethodNameError` naming convention).  
+For example, if the `get` method throws an error, the `onGetError` method is called. 
+
+Let's say you try to set a value into a store that uses the `localStorageAdapter`, but the `localStorage` is full: this will throw a `QuotaExceededError`.
+When this happens, you might want to clear the `localStorage` so you can save values to it again.
+You can do this by defining the `onSetError` method in your adapter:
+
 ```js
 import localStorageAdapter from 'browserstore.js/es/adapters/localStorage'
 
-
-const myLocalStorageAdapter = {...localStorageAdapter, ...{
-  onSetError(err, key, data) {
-    this.clear()
-    localStorage.set(key, data)
+const myLocalStorageAdapter = {
+  ...localStorageAdapter,
+  ...{
+    onSetError(err, key, data) {
+      this.clear()
+      this.set(key, data)
+    }
   }
-}}
-```
+}
 
 ## Using BrowserStore in different environments
 

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -14,13 +14,14 @@ const storeWithOnly = storeFactory({ only: ['foo'] })
 const storeWithConflicts = storeFactory({ only: ['bar'], ignore: ['bar'] })
 
 const errorHandler = jest.fn()
+const errorToThrow = Error("Error in adapter")
 const errorStoreAdapter = {
-  get(key) { throw Error('Error getting key') },
-  set(key, value) { throw Error('Error setting key') },
-  clear() { throw Error('Error clearing storage') },
-  remove(key) { throw Error('Error removing key') },
+  get(key) { throw errorToThrow },
+  set(key, value) { throw errorToThrow },
+  clear() { throw errorToThrow },
+  remove(key) { throw errorToThrow },
   onGetError(err, key) { errorHandler(err, key) },
-  onSetError(err, key, data) { errorHandler(err, key, data) },
+  onSetError(err, key, value) { errorHandler(err, key, value) },
   onRemoveError(err, key) { errorHandler(err, key) },
   onClearError(err) { errorHandler(err) },
 }
@@ -94,25 +95,26 @@ describe('createStore', () => {
   describe('#onGetError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.get('error')
-      expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toBeCalledWith(errorToThrow, 'error')
     })
   })
   describe('#onSetError', () => {
     test('calls error handler when there is an error', () => {
-      errorStore.set('error', 'error')
-      expect(errorHandler).toBeCalledTimes(1)
+      errorStore.set('error', 'value')
+      expect(errorHandler).toBeCalledWith(errorToThrow, 'error', 'value')
     })
   })
   describe('#onClearError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.clear()
-      expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toBeCalledWith(errorToThrow)
+
     })
   })
   describe('#onRemoveError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.remove('error')
-      expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toBeCalledWith(errorToThrow, 'error')
     })
   })
 })

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -17,7 +17,7 @@ const errorHandler = jest.fn()
 const errorStoreAdapter = {
   get(key) { throw Error('Error getting key') },
   set(key, value) { throw Error('Error setting key') },
-  clear() {throw Error('Error clearing storage') },
+  clear() { throw Error('Error clearing storage') },
   remove(key) { throw Error('Error removing key') },
   afterGet() {},
   beforeSet(data) { return data },

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -98,7 +98,7 @@ describe('createStore', () => {
     })
   })
   describe('#onSetError', () => {
-    test('calls error handler when there is an errorr', () => {
+    test('calls error handler when there is an error', () => {
       errorStore.set('error', 'error')
       expect(errorHandler).toBeCalledTimes(1)
     })

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -95,26 +95,26 @@ describe('createStore', () => {
   describe('#onGetError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.get('error')
-      expect(errorHandler).toBeCalledWith(errorToThrow, 'error')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'error')
     })
   })
   describe('#onSetError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.set('error', 'value')
-      expect(errorHandler).toBeCalledWith(errorToThrow, 'error', 'value')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'error', 'value')
     })
   })
   describe('#onClearError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.clear()
-      expect(errorHandler).toBeCalledWith(errorToThrow)
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow)
 
     })
   })
   describe('#onRemoveError', () => {
     test('calls error handler when there is an error', () => {
       errorStore.remove('error')
-      expect(errorHandler).toBeCalledWith(errorToThrow, 'error')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'error')
     })
   })
 })

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -19,8 +19,6 @@ const errorStoreAdapter = {
   set(key, value) { throw Error('Error setting key') },
   clear() { throw Error('Error clearing storage') },
   remove(key) { throw Error('Error removing key') },
-  afterGet() {},
-  beforeSet(data) { return data },
   onGetError(err, key) { errorHandler(err, key) },
   onSetError(err, key, data) { errorHandler(err, key, data) },
   onRemoveError(err, key) { errorHandler(err, key) },

--- a/src/__tests__/createStore.test.js
+++ b/src/__tests__/createStore.test.js
@@ -21,10 +21,10 @@ const errorStoreAdapter = {
   remove(key) { throw Error('Error removing key') },
   afterGet() {},
   beforeSet(data) { return data },
-  onGetError(error, key) { errorHandler(error, key) },
-  onSetError(error, key, data) { errorHandler(error, key, data) },
-  onRemoveError(error, key) { errorHandler(error, key) },
-  onClearError(error) { errorHandler(error) },
+  onGetError(err, key) { errorHandler(err, key) },
+  onSetError(err, key, data) { errorHandler(err, key, data) },
+  onRemoveError(err, key) { errorHandler(err, key) },
+  onClearError(err) { errorHandler(err) },
 }
 const errorStore = createStore(errorStoreAdapter)
 
@@ -94,25 +94,25 @@ describe('createStore', () => {
     })
   })
   describe('#onGetError', () => {
-    test('does call onGetError when there is an error', () => {
+    test('calls error handler when there is an error', () => {
       errorStore.get('error')
       expect(errorHandler).toBeCalledTimes(1)
     })
   })
   describe('#onSetError', () => {
-    test('does call onGetError when there is an error', () => {
+    test('calls error handler when there is an errorr', () => {
       errorStore.set('error', 'error')
       expect(errorHandler).toBeCalledTimes(1)
     })
   })
   describe('#onClearError', () => {
-    test('does call onClearError when there is an error', () => {
+    test('calls error handler when there is an error', () => {
       errorStore.clear()
       expect(errorHandler).toBeCalledTimes(1)
     })
   })
   describe('#onRemoveError', () => {
-    test('does call onRemoveError when there is an error', () => {
+    test('calls error handler when there is an error', () => {
       errorStore.remove('error')
       expect(errorHandler).toBeCalledTimes(1)
     })

--- a/src/adapters/storage.js
+++ b/src/adapters/storage.js
@@ -22,17 +22,17 @@ export default storage => {
     beforeSet(data) {
       return typeof data === 'string' ? data : JSON.stringify(data)
     },
-    onGetError(error) {
-      throw error
+    onGetError(err) {
+      throw err
     },
-    onSetError(error) {
-      throw error
+    onSetError(err) {
+      throw err
     },
-    onClearError(error) {
-      throw error
+    onClearError(err) {
+      throw err
     },
-    onRemoveError(error) {
-      throw error
+    onRemoveError(err) {
+      throw err
     },
   }
 }

--- a/src/adapters/storage.js
+++ b/src/adapters/storage.js
@@ -19,14 +19,20 @@ export default storage => {
         return data
       }
     },
-    onGetError(error) {
-      throw error
-    },
     beforeSet(data) {
       return typeof data === 'string' ? data : JSON.stringify(data)
     },
+    onGetError(error) {
+      throw error
+    },
     onSetError(error) {
       throw error
-    }
+    },
+    onClearError(error) {
+      throw error
+    },
+    onRemoveError(error) {
+      throw error
+    },
   }
 }

--- a/src/adapters/storage.js
+++ b/src/adapters/storage.js
@@ -19,8 +19,14 @@ export default storage => {
         return data
       }
     },
+    onGetError(error) {
+      throw error
+    },
     beforeSet(data) {
       return typeof data === 'string' ? data : JSON.stringify(data)
+    },
+    onSetError(error) {
+      throw error
     }
   }
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -27,10 +27,10 @@ export default (
         key => {
           try {
             return get(namespace + key)
-          } catch (e) {
-            if (!onGetError) throw e
+          } catch (err) {
+            if (!onGetError) throw err
 
-            return onGetError(e, key)
+            return onGetError(err, key)
           }
         },
         ...(afterGet ? [afterGet] : [])
@@ -42,11 +42,10 @@ export default (
         data => {
           try {
             if (!shouldIgnore(key)) return set(namespace + key, data)
-          } catch (e) {
-            if (!onSetError) throw e
+          } catch (err) {
+            if (!onSetError) throw err
 
-            return onSetError(e, key, data)
-
+            return onSetError(err, key, data)
           }
         }
       )(value)
@@ -54,19 +53,19 @@ export default (
     remove(key) {
       try {
         return remove(namespace + key)
-      } catch (e) {
-        if(!onRemoveError) throw e
+      } catch (err) {
+        if(!onRemoveError) throw err
 
-        return onRemoveError(e, key)
+        return onRemoveError(err, key)
       }
     },
     clear() {
       try {
         clear()
-      } catch (e) {
-        if(!onClearError) throw e
+      } catch (err) {
+        if(!onClearError) throw err
 
-        return onClearError(e)
+        return onClearError(err)
       }
     }
   }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -30,7 +30,7 @@ export default (
           } catch (e) {
             if (!onGetError) throw e
 
-            return onGetError(e, namespace + key)
+            return onGetError(e, key)
           }
         },
         ...(afterGet ? [afterGet] : [])
@@ -45,7 +45,7 @@ export default (
           } catch (e) {
             if (!onSetError) throw e
 
-            return onSetError(e, namespace + key, data)
+            return onSetError(e, key, data)
 
           }
         }
@@ -57,7 +57,7 @@ export default (
       } catch (e) {
         if(!onRemoveError) throw e
 
-        return onRemoveError(e, namespace + key)
+        return onRemoveError(e, key)
       }
     },
     clear() {

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -12,7 +12,7 @@ import pipe from './utils/pipe'
  * @returns {store}
  */
 export default (
-  { get, set, remove, clear, afterGet, beforeSet, onGetError, onSetError },
+  { get, set, remove, clear, afterGet, beforeSet, onGetError, onSetError, onRemoveError, onClearError },
   { namespace = '', ignore = [], only = [] } = {}
 ) => {
   const shouldIgnore = key => {
@@ -41,7 +41,7 @@ export default (
         ...(beforeSet ? [beforeSet] : []),
         data => {
           try {
-            if (! shouldIgnore(key)) return set(namespace + key, data)
+            if (!shouldIgnore(key)) return set(namespace + key, data)
           } catch (e) {
             if (!onSetError) throw e
 
@@ -52,8 +52,22 @@ export default (
       )(value)
     },
     remove(key) {
-      remove(namespace + key)
+      try {
+        return remove(namespace + key)
+      } catch (e) {
+        if(!onRemoveError) throw e
+
+        return onRemoveError(e, namespace + key)
+      }
     },
-    clear
+    clear() {
+      try {
+        clear()
+      } catch (e) {
+        if(!onClearError) throw e
+
+        return onClearError(e)
+      }
+    }
   }
 }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -44,7 +44,6 @@ export default (
             if (!shouldIgnore(key)) return set(namespace + key, data)
           } catch (err) {
             if (!onSetError) throw err
-
             return onSetError(err, key, data)
           }
         }
@@ -54,7 +53,7 @@ export default (
       try {
         return remove(namespace + key)
       } catch (err) {
-        if(!onRemoveError) throw err
+        if (!onRemoveError) throw err
 
         return onRemoveError(err, key)
       }
@@ -63,7 +62,7 @@ export default (
       try {
         clear()
       } catch (err) {
-        if(!onClearError) throw err
+        if (!onClearError) throw err
 
         return onClearError(err)
       }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -39,12 +39,12 @@ export default (
     set(key, value) {
       return pipe(
         ...(beforeSet ? [beforeSet] : []),
-        data => {
+        value => {
           try {
-            if (!shouldIgnore(key)) return set(namespace + key, data)
+            if (!shouldIgnore(key)) return set(namespace + key, value)
           } catch (err) {
             if (!onSetError) throw err
-            return onSetError(err, key, data)
+            return onSetError(err, key, value)
           }
         }
       )(value)

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -30,7 +30,7 @@ export default (
           } catch (e) {
             if (!onGetError) throw e
 
-            return onGetError(e, key)
+            return onGetError(e, namespace + key)
           }
         },
         ...(afterGet ? [afterGet] : [])
@@ -45,7 +45,7 @@ export default (
           } catch (e) {
             if (!onSetError) throw e
 
-            return onSetError(e, key, data)
+            return onSetError(e, namespace + key, data)
 
           }
         }


### PR DESCRIPTION
This PR adds a wrapper to handle errors while setting or getting data from one of the stores. This allows you to gracefully handle any limits a store might have, like size limits for example.

The proposed API in here is definitely not final, I would love to discuss about it here. 