### PR TITLE
feat: add error handling for multiStores

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,37 +281,37 @@ const myStorage = {
 const myStore = createStore(myStorage)
 ```
 
-##Handling errors
+## Handling errors
+
 ### Errors in multi-stores
-Multi-stores have built-in error handling methods too. 
+
+Like stores, multi-stores have built-in error handling methods as well. 
 You can customize the behavior by passing an object as the second parameter when creating your multi-store.
 
 ```js
 import localStorageAdapter from 'browserstore.js/es/adapters/localStorage'
 import sessionStorageAdapter from 'browserstore.js/es/adapters/sessionStorage'
 import { createStore, multiStore } from 'browserstore.js'
+const stores = multiStore(
+  [createStore(localStorageAdapter), createStore(sessionStorageAdapter)],
+  {
+    onGetError(err, key, currentStore, nextStore) {
+      return nextStore.get(key)
+    },
+    onSetError(err, key, currentStore, nextStore) {
+      currentStore.clear()
+      return currentStore.set(key)
+    },
+    onClearError(err) {
+      console.error(err)
+    },
+    onRemoveError(err, key) {
+      console.error(err, key)
+    }
+  }
+)
 
-const stores = multiStore([
-  createStore(localStorageAdapter),
-  createStore(sessionStorageAdapter)
-], {
-  onGetError(err, key) {
-    return err.nextStore.get(key)
-  },
-  onSetError(err, key) {
-    err.currentStore.clear()
-    return err.nextStore.set(key)
-  },
-  onClearError(err) {
-    // Do nothing and ignore the error
-  },
-  onRemoveError(err, key) {
-    // Do nothing and ignore the error
-  },
-})
-```
-
-BrowserStore will append two properties to the error thrown by a store before it's passed to your callback: the `currentStore` (the store that throws the error), and `nextStore` (the next store in the execution chain).
+Each error handling callback exposes the `currentStore` (the store that threw the error) and `nextStore` (the next store in the execution chain).
 
 ## Using BrowserStore in different environments
 

--- a/README.md
+++ b/README.md
@@ -302,16 +302,17 @@ const stores = multiStore(
       currentStore.clear()
       return currentStore.set(key)
     },
-    onClearError(err) {
+    onClearError(err, currentStore, nextStore) {
       console.error(err)
     },
-    onRemoveError(err, key) {
+    onRemoveError(err, key, currentStore, nextStore) {
       console.error(err, key)
     }
   }
 )
+```
 
-Each error handling callback exposes the `currentStore` (the store that threw the error) and `nextStore` (the next store in the execution chain).
+Each error handling callback exposes the `currentStore` (the store that threw the error) and `nextStore` (the next store in the execution chain, or `undefined` if the current store is the last in the chain).
 
 ## Using BrowserStore in different environments
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,38 @@ const myStorage = {
 const myStore = createStore(myStorage)
 ```
 
+##Handling errors
+### Errors in multi-stores
+Multi-stores have built-in error handling methods too. 
+You can customize the behavior by passing an object as the second parameter when creating your multi-store.
+
+```js
+import localStorageAdapter from 'browserstore.js/es/adapters/localStorage'
+import sessionStorageAdapter from 'browserstore.js/es/adapters/sessionStorage'
+import { createStore, multiStore } from 'browserstore.js'
+
+const stores = multiStore([
+  createStore(localStorageAdapter),
+  createStore(sessionStorageAdapter)
+], {
+  onGetError(err, key) {
+    return err.nextStore.get(key)
+  },
+  onSetError(err, key) {
+    err.currentStore.clear()
+    return err.nextStore.set(key)
+  },
+  onClearError(err) {
+    // Do nothing and ignore the error
+  },
+  onRemoveError(err, key) {
+    // Do nothing and ignore the error
+  },
+})
+```
+
+BrowserStore will append two properties to the error thrown by a store before it's passed to your callback: the `currentStore` (the store that throws the error), and `nextStore` (the next store in the execution chain).
+
 ## Using BrowserStore in different environments
 
 BrowserStore is built with modularity in mind. Yet, this isn't always practical depending on your use case and your environment. For instance, if you're using a library right in the browser with a `<script>` tag, it's easier to access everything from a global namespace. However, if you're in a Node environment, or if you have a build step in your pipeline, importing the library piece by piece is much more idiomatic.

--- a/src/__tests__/multiStore.test.js
+++ b/src/__tests__/multiStore.test.js
@@ -20,9 +20,9 @@ const errorStores = multiStore([
   createStore(errorStoreAdapter, { namespace: 'browserstore_' }),
   createStore(localStorageAdapter, { namespace: 'browserstore_' })
 ], {
-  onGetError(key, err) { errorHandler(key, err) },
-  onSetError(key, data, err) { errorHandler(key, data, err) },
-  onRemoveError(key, err) { errorHandler(key, err) },
+  onGetError(err, key) { errorHandler(err, key) },
+  onSetError(err, key, data) { errorHandler(err, key, data) },
+  onRemoveError(err, key) { errorHandler(err, key) },
   onClearError(err) { errorHandler(err) },
 })
 
@@ -54,7 +54,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.get('foo')
       expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith('foo', errorToThrow)
+      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo')
     })
   })
   describe('#set', () => {
@@ -71,7 +71,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.set('foo', 'bar')
       expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith('foo', 'bar', errorToThrow)
+      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo', 'bar')
     })
   })
   describe('#remove', () => {
@@ -85,7 +85,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.remove('foo')
       expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith('foo', errorToThrow)
+      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo')
     })
   })
   describe('#clear', () => {

--- a/src/__tests__/multiStore.test.js
+++ b/src/__tests__/multiStore.test.js
@@ -21,7 +21,7 @@ const errorStores = multiStore([
   createStore(localStorageAdapter, { namespace: 'browserstore_' })
 ], {
   onGetError(err, key) { errorHandler(err, key) },
-  onSetError(err, key, data) { errorHandler(err, key, data) },
+  onSetError(err, key, value) { errorHandler(err, key, value) },
   onRemoveError(err, key) { errorHandler(err, key) },
   onClearError(err) { errorHandler(err) },
 })

--- a/src/__tests__/multiStore.test.js
+++ b/src/__tests__/multiStore.test.js
@@ -10,8 +10,8 @@ const errorToThrow = Error('This is an error')
 const errorStoreAdapter = {
   get(key) { throw errorToThrow },
   set(key) { throw errorToThrow },
-  remove(key){ throw errorToThrow},
-  clear(){ throw errorToThrow},
+  remove(key) { throw errorToThrow },
+  clear() { throw errorToThrow },
 }
 
 const errorHandler = jest.fn()

--- a/src/__tests__/multiStore.test.js
+++ b/src/__tests__/multiStore.test.js
@@ -15,15 +15,17 @@ const errorStoreAdapter = {
 }
 
 const errorHandler = jest.fn()
+const errorStore = createStore(errorStoreAdapter)
+const localStorageStore = createStore(localStorageAdapter, { namespace: 'browserstore_' })
 
 const errorStores = multiStore([
-  createStore(errorStoreAdapter, { namespace: 'browserstore_' }),
-  createStore(localStorageAdapter, { namespace: 'browserstore_' })
+  errorStore,
+  localStorageStore
 ], {
-  onGetError(err, key) { errorHandler(err, key) },
-  onSetError(err, key, value) { errorHandler(err, key, value) },
-  onRemoveError(err, key) { errorHandler(err, key) },
-  onClearError(err) { errorHandler(err) },
+  onGetError(err, key, currentStore, nextStore) { errorHandler(err, key, currentStore, nextStore) },
+  onSetError(err, key, value, currentStore, nextStore) { errorHandler(err, key, value, currentStore, nextStore) },
+  onRemoveError(err, key, currentStore, nextStore) { errorHandler(err, key, currentStore, nextStore) },
+  onClearError(err, currentStore, nextStore) { errorHandler(err, currentStore, nextStore) },
 })
 
 const stores = multiStore([
@@ -53,8 +55,7 @@ describe('multiStore', () => {
     })
     test('calls the error handler if an error is thrown', () => {
       errorStores.get('foo')
-      expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'foo', errorStore, localStorageStore)
     })
   })
   describe('#set', () => {
@@ -70,8 +71,7 @@ describe('multiStore', () => {
     })
     test('calls the error handler if an error is thrown', () => {
       errorStores.set('foo', 'bar')
-      expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo', 'bar')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'foo', 'bar', errorStore, localStorageStore)
     })
   })
   describe('#remove', () => {
@@ -84,8 +84,7 @@ describe('multiStore', () => {
     })
     test('calls the error handler if an error is thrown', () => {
       errorStores.remove('foo')
-      expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith(errorToThrow, 'foo')
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, 'foo', errorStore, localStorageStore)
     })
   })
   describe('#clear', () => {
@@ -102,8 +101,7 @@ describe('multiStore', () => {
     })
     test('calls the error handler if an error is thrown', () => {
       errorStores.clear()
-      expect(errorHandler).toBeCalledTimes(1)
-      expect(errorHandler).toHaveBeenCalledWith(errorToThrow)
+      expect(errorHandler).toHaveBeenNthCalledWith(1, errorToThrow, errorStore, localStorageStore)
     })
   })
 })

--- a/src/__tests__/multiStore.test.js
+++ b/src/__tests__/multiStore.test.js
@@ -6,11 +6,12 @@ import { createStore, multiStore } from '../browserstore'
 const getParams = () =>
   new URLSearchParams(new URL(window.location.href).search)
 
+const errorToThrow = Error('This is an error')
 const errorStoreAdapter = {
-  get(key) { throw Error('This is an error') },
-  set(key) { throw Error('This is an error') },
-  remove(key){ throw Error('This is an error')},
-  clear(){ throw Error('This is an error')},
+  get(key) { throw errorToThrow },
+  set(key) { throw errorToThrow },
+  remove(key){ throw errorToThrow},
+  clear(){ throw errorToThrow},
 }
 
 const errorHandler = jest.fn()
@@ -19,10 +20,10 @@ const errorStores = multiStore([
   createStore(errorStoreAdapter, { namespace: 'browserstore_' }),
   createStore(localStorageAdapter, { namespace: 'browserstore_' })
 ], {
-  onGetError(key, e) { errorHandler(key, e) },
-  onSetError(key, data, e) { errorHandler(key, data, e) },
-  onRemoveError(key, e) { errorHandler(key, e) },
-  onClearError(e) { errorHandler(e) },
+  onGetError(key, err) { errorHandler(key, err) },
+  onSetError(key, data, err) { errorHandler(key, data, err) },
+  onRemoveError(key, err) { errorHandler(key, err) },
+  onClearError(err) { errorHandler(err) },
 })
 
 const stores = multiStore([
@@ -53,6 +54,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.get('foo')
       expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toHaveBeenCalledWith('foo', errorToThrow)
     })
   })
   describe('#set', () => {
@@ -69,6 +71,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.set('foo', 'bar')
       expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toHaveBeenCalledWith('foo', 'bar', errorToThrow)
     })
   })
   describe('#remove', () => {
@@ -82,6 +85,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.remove('foo')
       expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toHaveBeenCalledWith('foo', errorToThrow)
     })
   })
   describe('#clear', () => {
@@ -99,6 +103,7 @@ describe('multiStore', () => {
     test('calls the error handler if an error is thrown', () => {
       errorStores.clear()
       expect(errorHandler).toBeCalledTimes(1)
+      expect(errorHandler).toHaveBeenCalledWith(errorToThrow)
     })
   })
 })

--- a/src/multiStore.js
+++ b/src/multiStore.js
@@ -2,11 +2,10 @@
  * Creates a multi-store
  *
  * @param {store[]} stores - The stores to sync.
- * @param {object} [errorHandlers] - Functions to override the error handling behavior.
- * @param {function} [errorHandlers.onGetError] - A function to execute if a store errors when getting a value.
- * @param {function} [errorHandlers.onSetError] - A function to execute if a store errors when setting a value.
- * @param {function} [errorHandlers.onClearError] - A function to execute if a store errors when clearing all values.
- * @param {function} [errorHandlers.onRemoveError] - A function to execute if a store errors when removing a value.
+ * @param {function} [options.onGetError] - A callback to execute if a store errors when getting a value.
+ * @param {function} [options.onSetError] - A callback to execute if a store errors when setting a value.
+ * @param {function} [options.onClearError] - A callback to execute if a store errors when clearing all values.
+ * @param {function} [options.onRemoveError] - A callback to execute if a store errors when removing a value.
  *
  * @returns {object}
  */
@@ -27,10 +26,10 @@ export default (
       for (let i = 0; i < stores.length; i++) {
         try {
           data = stores[i].get(key)
-        } catch (e) {
-          if (!onGetError) throw e
+        } catch (err) {
+          if (!onGetError) throw err
 
-          data = onGetError(key, formatError(e, i))
+          data = onGetError(key, formatError(err, i))
         }
 
         if (data) break
@@ -41,10 +40,10 @@ export default (
       stores.forEach((store, i) => {
         try {
           store.set(key, value)
-        } catch (e) {
-          if (!onSetError) throw e
+        } catch (err) {
+          if (!onSetError) throw err
 
-          onSetError(key, value, formatError(e, i))
+          onSetError(key, value, formatError(err, i))
         }
       })
     },
@@ -52,10 +51,10 @@ export default (
       stores.forEach((store, i) => {
         try {
           store.remove(key)
-        } catch (e) {
-          if (!onRemoveError) throw e
+        } catch (err) {
+          if (!onRemoveError) throw err
 
-          onRemoveError(key, formatError(e, i))
+          onRemoveError(key, formatError(err, i))
         }
       })
     },
@@ -63,10 +62,10 @@ export default (
       stores.forEach((store, i) => {
         try {
           store.clear()
-        } catch (e) {
-          if (!onClearError) throw e
+        } catch (err) {
+          if (!onClearError) throw err
 
-          onClearError(formatError(e, i))
+          onClearError(formatError(err, i))
         }
       })
     }

--- a/src/multiStore.js
+++ b/src/multiStore.js
@@ -2,27 +2,73 @@
  * Creates a multi-store
  *
  * @param {store[]} stores - The stores to sync.
+ * @param {object} [errorHandlers] - Functions to override the error handling behavior.
+ * @param {function} [errorHandlers.onGetError] - A function to execute if a store errors when getting a value.
+ * @param {function} [errorHandlers.onSetError] - A function to execute if a store errors when setting a value.
+ * @param {function} [errorHandlers.onClearError] - A function to execute if a store errors when clearing all values.
+ * @param {function} [errorHandlers.onRemoveError] - A function to execute if a store errors when removing a value.
  *
  * @returns {object}
  */
-export default stores => {
+export default (
+  stores, 
+  { onGetError, onSetError, onClearError, onRemoveError } = {}
+) => {
+  const formatError = (err, storeIndex) => {
+    err.currentStore = stores[storeIndex]
+    err.nextStore = stores[storeIndex + 1]
+
+    return err
+  }
+
   return {
     get(key) {
       let data = null
       for (let i = 0; i < stores.length; i++) {
-        data = stores[i].get(key)
+        try {
+          data = stores[i].get(key)
+        } catch (e) {
+          if (!onGetError) throw e
+
+          data = onGetError(key, formatError(e, i))
+        }
+
         if (data) break
       }
       return data
     },
     set(key, value) {
-      stores.forEach(store => store.set(key, value))
+      stores.forEach((store, i) => {
+        try {
+          store.set(key, value)
+        } catch (e) {
+          if (!onSetError) throw e
+
+          onSetError(key, value, formatError(e, i))
+        }
+      })
     },
     remove(key) {
-      stores.forEach(store => store.remove(key))
+      stores.forEach((store, i) => {
+        try {
+          store.remove(key)
+        } catch (e) {
+          if (!onRemoveError) throw e
+
+          onRemoveError(key, formatError(e, i))
+        }
+      })
     },
     clear() {
-      stores.forEach(store => store.clear())
+      stores.forEach((store, i) => {
+        try {
+          store.clear()
+        } catch (e) {
+          if (!onClearError) throw e
+
+          onClearError(formatError(e, i))
+        }
+      })
     }
   }
 }

--- a/src/multiStore.js
+++ b/src/multiStore.js
@@ -29,7 +29,7 @@ export default (
         } catch (err) {
           if (!onGetError) throw err
 
-          data = onGetError(key, formatError(err, i))
+          data = onGetError(formatError(err, i), key)
         }
 
         if (data) break
@@ -43,7 +43,7 @@ export default (
         } catch (err) {
           if (!onSetError) throw err
 
-          onSetError(key, value, formatError(err, i))
+          onSetError(formatError(err, i), key, value)
         }
       })
     },
@@ -54,7 +54,7 @@ export default (
         } catch (err) {
           if (!onRemoveError) throw err
 
-          onRemoveError(key, formatError(err, i))
+          onRemoveError(formatError(err, i), key)
         }
       })
     },

--- a/src/multiStore.js
+++ b/src/multiStore.js
@@ -13,13 +13,6 @@ export default (
   stores, 
   { onGetError, onSetError, onClearError, onRemoveError } = {}
 ) => {
-  const formatError = (err, storeIndex) => {
-    err.currentStore = stores[storeIndex]
-    err.nextStore = stores[storeIndex + 1]
-
-    return err
-  }
-
   return {
     get(key) {
       let data = null
@@ -29,7 +22,7 @@ export default (
         } catch (err) {
           if (!onGetError) throw err
 
-          data = onGetError(formatError(err, i), key)
+          data = onGetError(err, key, stores[i], stores[i + 1])
         }
 
         if (data) break
@@ -43,7 +36,7 @@ export default (
         } catch (err) {
           if (!onSetError) throw err
 
-          onSetError(formatError(err, i), key, value)
+          onSetError(err, key, value, stores[i], stores[i + 1])
         }
       })
     },
@@ -54,7 +47,7 @@ export default (
         } catch (err) {
           if (!onRemoveError) throw err
 
-          onRemoveError(formatError(err, i), key)
+          onRemoveError(err, key, stores[i], stores[i + 1])
         }
       })
     },
@@ -65,7 +58,7 @@ export default (
         } catch (err) {
           if (!onClearError) throw err
 
-          onClearError(formatError(err, i))
+          onClearError(err, stores[i], stores[i + 1])
         }
       })
     }


### PR DESCRIPTION
This PR adds abstractions to add error handling to the multiStores. Each error handler will receive (if applicable) the `key` and `data` passed to the original function, an an error with the `currentStore` and `nextStore` properties so you can handle the logic in the way you want.